### PR TITLE
Update module.json

### DIFF
--- a/module.json
+++ b/module.json
@@ -93,6 +93,6 @@
   ],
   "url": "https://github.com/ZigmundKreud/cof-srd.git",
   "manifest": "https://raw.githubusercontent.com/ZigmundKreud/cof-srd/main/module.json",
-  "download": "https://github.com/ZigmundKreud/cof-srd/archive/refs/tags/0.8.9.1.zip",
+  "download": "https://github.com/ZigmundKreud/cof-srd/archive/refs/tags/0.8.9.2.zip",
   "license": "licence.txt"
 }


### PR DESCRIPTION
Tag qui pointe par erreur vers 0.8.9.1 au lieu de 0.8.9.2